### PR TITLE
Preserve source references

### DIFF
--- a/examples/rps.pl
+++ b/examples/rps.pl
@@ -1,0 +1,22 @@
+:- use_module(library(scasp)).
+:- use_module(library(scasp/human)).
+
+#pred player(G, X) :: '@(X) played in @(G)'.
+#pred winner(Game,Player) :: 'The winner of @(Game) is @(Player)'.
+#pred throw(Player,Sign) :: '@(Player) threw @(Sign)'.
+#pred beat(Sign,OtherSign) :: '@(Sign) beats @(OtherSign)'.
+
+beat(rock,scissors).
+beat(scissors,paper).
+beat(paper,rock).
+
+#abducible player(Game, Player).
+#abducible throw(Player, Sign).
+
+winner(Game,Player) :-
+  player(Game, Player),
+  player(Game, OtherPlayer),
+  throw(Player,Sign),
+  throw(OtherPlayer,OtherSign),
+  beat(Sign,OtherSign).
+

--- a/examples/rps.pl
+++ b/examples/rps.pl
@@ -1,10 +1,10 @@
 :- use_module(library(scasp)).
 :- use_module(library(scasp/human)).
 
-#pred player(G, X) :: '@(X) played in @(G)'.
-#pred winner(Game,Player) :: 'The winner of @(Game) is @(Player)'.
-#pred throw(Player,Sign) :: '@(Player) threw @(Sign)'.
-#pred beat(Sign,OtherSign) :: '@(Sign) beats @(OtherSign)'.
+#pred player('G', 'X') :: '@(X) played in @(G)'.
+#pred winner('Game','Player') :: 'The winner of @(Game) is @(Player)'.
+#pred throw('Player','Sign') :: '@(Player) threw @(Sign)'.
+#pred beat('Sign','OtherSign') :: '@(Sign) beats @(OtherSign)'.
 
 beat(rock,scissors).
 beat(scissors,paper).
@@ -19,4 +19,6 @@ winner(Game,Player) :-
   throw(Player,Sign),
   throw(OtherPlayer,OtherSign),
   beat(Sign,OtherSign).
+
+
 

--- a/prolog/scasp.pl
+++ b/prolog/scasp.pl
@@ -89,9 +89,15 @@ s(CASP) programs in Prolog and query them from Prolog.
 		 *******************************/
 
 :- multifile
-    sandbox:safe_meta_predicate/1.
+    sandbox:safe_meta_predicate/1,
+    sandbox:safe_prolog_flag/2.
 
 sandbox:safe_meta(scasp:(? _), []).
 sandbox:safe_meta(scasp:(?? _), []).
 
+sandbox:safe_prolog_flag(scasp_unknown, _).
+sandbox:safe_prolog_flag(scasp_plain_dual, _).
+sandbox:safe_prolog_flag(scasp_compile_olon, _).
+sandbox:safe_prolog_flag(scasp_compile_nmr, _).
+sandbox:safe_prolog_flag(scasp_dcc, _).
 

--- a/prolog/scasp.pl
+++ b/prolog/scasp.pl
@@ -84,4 +84,14 @@ s(CASP) programs in Prolog and query them from Prolog.
         set_prolog_flag(scasp_show_justification, Old)).
 
 
+		 /*******************************
+		 *            SANDBOX		*
+		 *******************************/
+
+:- multifile
+    sandbox:safe_meta_predicate/1.
+
+sandbox:safe_meta(scasp:(? _), []).
+sandbox:safe_meta(scasp:(?? _), []).
+
 

--- a/prolog/scasp.pl
+++ b/prolog/scasp.pl
@@ -95,6 +95,7 @@ s(CASP) programs in Prolog and query them from Prolog.
 sandbox:safe_meta(scasp:(? _), []).
 sandbox:safe_meta(scasp:(?? _), []).
 
+sandbox:safe_prolog_flag(scasp_lang, _).
 sandbox:safe_prolog_flag(scasp_unknown, _).
 sandbox:safe_prolog_flag(scasp_plain_dual, _).
 sandbox:safe_prolog_flag(scasp_compile_olon, _).

--- a/prolog/scasp/comp_duals.pl
+++ b/prolog/scasp/comp_duals.pl
@@ -74,7 +74,7 @@ comp_dual(X) :-
     scasp_builtin(X),		% skip dual of scasp builtins
     !.
 comp_dual(X) :-
-    findall(R, (defined_rule(X, H, B), c_rule(R, H, B)), Rs), % get rules for a single predicate
+    findall(R, (defined_rule(X, H, B, _), c_rule(R, H, B)), Rs), % get rules for a single predicate
     comp_duals3(X, Rs).
 
 %!  comp_duals3(+Predicate:atom, +Rules:list) is det
@@ -94,13 +94,13 @@ comp_duals3(P, []) :-
     predicate(H, P, []), % create a dummy predicate for outer_dual_head/2.
     outer_dual_head(H, Hd),
     c_rule(Rd, Hd, []),
-    assert_rule(Rd).
+    assert_rule(dual(Rd)).
 comp_duals3(P, R) :- % predicate is defined by one or more rules.
     predicate(H, P, []), % create a dummy predicate for P.
     outer_dual_head(H, Hd),
     comp_dual(Hd, R, Db, 1),
     c_rule(Rd, Hd, Db),
-    assert_rule(Rd).
+    assert_rule(dual(Rd)).
 
 %!  comp_dual(+DualHead:compound, +Rules:list, -DualBody:list, +Count:int) is det
 %
@@ -163,7 +163,7 @@ comp_dual2(Hn, Bg, Bv) :-
     define_forall(Hn2, G, Bv), % get the call to the innermost dual
     comp_dual3(Hn2, Bg, []), % create innermost duals
     c_rule(Rd, Hn, [G]), % create dual
-    assert_rule(Rd).
+    assert_rule(dual(Rd)).
 
 %!  comp_dual3(+DualHead:compound, +Body:list, +UsedGoals:list) is det
 %
@@ -195,7 +195,7 @@ comp_dual3(Hn, [X|T], U) :-
     ;   append(U, [X2], Db) % Keep all goals prior to the dual one.
     ),
     c_rule(Rd, Hn, Db), % Clause for negation of body goal
-    assert_rule(Rd),
+    assert_rule(dual(Rd)),
     append(U, [X], U2),
     comp_dual3(Hn, T, U2).
 

--- a/prolog/scasp/compile.pl
+++ b/prolog/scasp/compile.pl
@@ -69,7 +69,7 @@ results.
 %   Load the files from Sources.   Steps taken:
 %
 %     - Parse input and assert in dynamic predicates with
-%       program.pl (defined_rule/3, etc,)
+%       program.pl (defined_rule/4, etc,)
 %     - Enrich the program in the same format (comp_duals/0,
 %       generate_nmr_check/0).
 %     - Transform into _pr_ rules (generate_pr_rules/1)

--- a/prolog/scasp/dyncall.pl
+++ b/prolog/scasp/dyncall.pl
@@ -165,10 +165,10 @@ scasp_query_clauses(Query, Clauses) :-
     findall(Clause, scasp_clause(Callees, Clause), Clauses, QConstraints),
     maplist(mkconstraint, Constraints, QConstraints).
 
-scasp_clause(Callees, Clause) :-
+scasp_clause(Callees, clause(ClauseRef, Clause)) :-
     member(PI, Callees),
     pi_head(PI, M:Head),
-    @(clause(Head, Body), M),
+    @(clause(Head, Body, ClauseRef), M),
     mkclause(Head, Body, M, Clause).
 
 mkclause(Head, true, M, Clause) =>

--- a/prolog/scasp/dyncall.pl
+++ b/prolog/scasp/dyncall.pl
@@ -600,3 +600,4 @@ user:goal_expansion(-Goal, MGoal) :-
 % lists:member(...),
 
 sandbox:safe_meta(scasp_dyncall:scasp(_), []).
+sandbox:safe_meta(scasp_dyncall:scasp(_, _), []).

--- a/prolog/scasp/html.pl
+++ b/prolog/scasp/html.pl
@@ -9,6 +9,7 @@
 :- use_module(common).
 :- use_module(output).
 :- use_module(html_text).
+:- use_module(messages).
 
 :- use_module(library(http/html_write)).
 :- use_module(library(http/term_html)).
@@ -662,60 +663,37 @@ action(Term, Options) -->
 %
 %   Emit a logical connector.
 
-connector(Meaning, Options) -->
-    { language(Lang, Options) },
-    connector(Meaning, Lang, Options).
-
-connector(and, Lang, _Options) -->
-    { human_connector(and, Lang, Text) },
+connector(and, _Options) -->
+    { human_connector(and, Text) },
     emit([ span(class(human), Text),
            span(class(machine), ',')
          ]).
-connector(not, Lang, _Options) -->
-    { human_connector(not, Lang, Text) },
+connector(not, _Options) -->
+    { human_connector(not, Text) },
     emit([ span(class(human), Text),
            span(class(machine), 'not ')
          ]).
-connector(-, Lang, _Options) -->
-    { human_connector(-, Lang, Text) },
+connector(-, _Options) -->
+    { human_connector(-, Text) },
     emit([ span(class(human), Text),
            span(class(machine), '\u00ac ')
          ]).
-connector(implies, Lang, _Options) -->
-    { human_connector(implies, Lang, Text) },
+connector(implies, _Options) -->
+    { human_connector(implies, Text) },
     emit([ span(class(human), Text),
            span(class(machine), ' \u2190')
          ]).
-connector(?, Lang, _Options) -->
-    { human_connector(?, Lang, Text) },
+connector(?, _Options) -->
+    { human_connector(?, Text) },
     emit([ span(class(human), Text),
            span(class(machine), '.')
          ]).
-connector('.', _Lang, _Options) -->
+connector('.', _Options) -->
     emit([ span(class('full-stop'), '.')
          ]).
 
-human_connector(implies, es, ', porque').
-human_connector(and,     _,  ', and').
-human_connector(not,     _,  'there is no evidence that ').
-human_connector(-,       _,  'it is not the case that ').
-human_connector(implies, _,  ', because').
-human_connector(?,       _,  '?').
-
-%!  language(-Lang, +Options) is det.
-%
-%   Establish the langauge for the output.   Currently  uses the Logical
-%   English conventions. Might be better to use a Prolog flag? Note that
-%   we already have a flag that controls whether we use Unicode symbols.
-
-language(Lang, Options) :-
-    (   option(module(M), Options),
-        current_predicate(M:source_lang/1),
-        M:source_lang(Lang0)
-    ->  true
-    ;   Lang0 = en
-    ),
-    Lang = Lang0.
+human_connector(Term, String) :-
+    phrase(scasp_justification_message(Term), [String]).
 
 full_stop(_Options) -->
     emit('\u220e').                     % QED block

--- a/prolog/scasp/html.pl
+++ b/prolog/scasp/html.pl
@@ -388,7 +388,7 @@ atom(is(Value,Expr), Options) -->
     },
     emit(span(class([arithmetic|Classes]), S)).
 atom(Comp, Options) -->
-    { comp(Comp, Text),
+    { human_connector(Comp, Text),
       !,
       Comp =.. [_,Left,Right]
     },
@@ -407,11 +407,6 @@ atom(Term, Options) -->
 atom(Term, Options) -->
     utter(holds(Term), Options).
 
-comp(_>_, 'is greater than').
-comp(_>=_, 'is greater than or equal to').
-comp(_<_, 'is less than').
-comp(_=<_, 'is less than or equal to').
-
 %!  utter(+Exppression, +Options)
 
 utter(global_constraints_hold, _Options) -->
@@ -420,23 +415,23 @@ utter(global_constraint(N), _Options) -->
     emit('the global constraint number ~p holds'-[N]).
 utter(not(Atom), Options) -->
     { human_connector(not, Text) },
-    emit(Text),
+    emit([Text, ' ']),
     atom(Atom, Options).
 utter(-(Atom), Options) -->
     { human_connector(-, Text) },
-    emit(Text),
+    emit([Text, ' ']),
     atom(Atom, Options).
 utter(proved(Atom), Options) -->
     { human_connector(proved, Text) },
     atom(Atom, Options),
-    emit(Text).
+    emit([', ', Text]).
 utter(chs(Atom), Options) -->
     { human_connector(chs, Text) },
-    emit(Text),
+    emit([Text, ' ']),
     atom(Atom, Options).
 utter(assume(Atom), Options) -->
     { human_connector(assume, Text) },
-    emit(Text),
+    emit([Text, ' ']),
     atom(Atom, Options).
 utter(holds(Atom), Options) -->
     { css_classes(Options, Classes) },
@@ -537,9 +532,11 @@ inlined_var(Var, Constraints, Options) -->
     },
     !,
     (   {List = [One]}
-    ->  emit([var(Name), ' other than ']),
+    ->  {human_connector(neq, Text)},
+        emit([var(Name), Text]),
         scasp_term(One, Options)
-    ;   emit([var(Name), ' not ']),
+    ;   {human_connector(not_in, Text)},
+        emit([var(Name), Text]),
         list(List, [last_connector(or)|Options])
     ).
 inlined_var(Var, Constraints, Options) -->
@@ -643,9 +640,11 @@ inlined_typed_var(Var, Type, Constraints, Options) --> % TBD: include type in NL
 
 list([L1,L], Options) -->
     !,
-    { option(last_connector(Conn), Options, 'and') },
+    { option(last_connector(Conn), Options, and),
+      human_connector(Conn, Text)
+    },
     scasp_term(L1, Options),
-    emit(', ~w '-[Conn]),
+    emit(', ~w '-[Text]),
     scasp_term(L, Options).
 list([H|T], Options) -->
     scasp_term(H, Options),
@@ -672,22 +671,22 @@ action(Term, Options) -->
 
 connector(and, _Options) -->
     { human_connector(and, Text) },
-    emit([ span(class(human), Text),
+    emit([ span(class(human), [', ', Text]),
            span(class(machine), ',')
          ]).
 connector(not, _Options) -->
     { human_connector(not, Text) },
-    emit([ span(class(human), Text),
+    emit([ span(class(human), [Text, ' ']),
            span(class(machine), 'not ')
          ]).
 connector(-, _Options) -->
     { human_connector(-, Text) },
-    emit([ span(class(human), Text),
+    emit([ span(class(human), [Text, ' ']),
            span(class(machine), '\u00ac ')
          ]).
 connector(implies, _Options) -->
     { human_connector(implies, Text) },
-    emit([ span(class(human), Text),
+    emit([ span(class(human), [', ', Text]),
            span(class(machine), ' \u2190')
          ]).
 connector(?, _Options) -->

--- a/prolog/scasp/html.pl
+++ b/prolog/scasp/html.pl
@@ -662,29 +662,60 @@ action(Term, Options) -->
 %
 %   Emit a logical connector.
 
-connector(and, _Options) -->
-    emit([ span(class(human), ', and'),
+connector(Meaning, Options) -->
+    { language(Lang, Options) },
+    connector(Meaning, Lang, Options).
+
+connector(and, Lang, _Options) -->
+    { human_connector(and, Lang, Text) },
+    emit([ span(class(human), Text),
            span(class(machine), ',')
          ]).
-connector(not, _Options) -->
-    emit([ span(class(human), 'there is no evidence that '),
+connector(not, Lang, _Options) -->
+    { human_connector(not, Lang, Text) },
+    emit([ span(class(human), Text),
            span(class(machine), 'not ')
          ]).
-connector(-, _Options) -->
-    emit([ span(class(human), 'it is not the case that '),
+connector(-, Lang, _Options) -->
+    { human_connector(-, Lang, Text) },
+    emit([ span(class(human), Text),
            span(class(machine), '\u00ac ')
          ]).
-connector(implies, _Options) -->
-    emit([ span(class(human), ', because'),
+connector(implies, Lang, _Options) -->
+    { human_connector(implies, Lang, Text) },
+    emit([ span(class(human), Text),
            span(class(machine), ' \u2190')
          ]).
-connector(?, _Options) -->
-    emit([ span(class(human), '?'),
+connector(?, Lang, _Options) -->
+    { human_connector(?, Lang, Text) },
+    emit([ span(class(human), Text),
            span(class(machine), '.')
          ]).
-connector(., _Options) -->
+connector('.', _Lang, _Options) -->
     emit([ span(class('full-stop'), '.')
          ]).
+
+human_connector(implies, es, ', porque').
+human_connector(and,     _,  ', and').
+human_connector(not,     _,  'there is no evidence that ').
+human_connector(-,       _,  'it is not the case that ').
+human_connector(implies, _,  ', because').
+human_connector(?,       _,  '?').
+
+%!  language(-Lang, +Options) is det.
+%
+%   Establish the langauge for the output.   Currently  uses the Logical
+%   English conventions. Might be better to use a Prolog flag? Note that
+%   we already have a flag that controls whether we use Unicode symbols.
+
+language(Lang, Options) :-
+    (   option(module(M), Options),
+        current_predicate(M:source_lang/1),
+        M:source_lang(Lang0)
+    ->  true
+    ;   Lang0 = en
+    ),
+    Lang = Lang0.
 
 full_stop(_Options) -->
     emit('\u220e').                     % QED block

--- a/prolog/scasp/html.pl
+++ b/prolog/scasp/html.pl
@@ -410,9 +410,11 @@ atom(Term, Options) -->
 %!  utter(+Exppression, +Options)
 
 utter(global_constraints_hold, _Options) -->
-    emit('The global constraints hold').
+    { human_connector(global_constraints_hold, Text) },
+    emit(Text).
 utter(global_constraint(N), _Options) -->
-    emit('the global constraint number ~p holds'-[N]).
+    { human_connector(global_constraint(N), Text) },
+    emit(Text).
 utter(not(Atom), Options) -->
     { human_connector(not, Text) },
     emit([Text, ' ']),
@@ -533,10 +535,10 @@ inlined_var(Var, Constraints, Options) -->
     !,
     (   {List = [One]}
     ->  {human_connector(neq, Text)},
-        emit([var(Name), Text]),
+        emit([var(Name), ' ', Text, ' ']),
         scasp_term(One, Options)
     ;   {human_connector(not_in, Text)},
-        emit([var(Name), Text]),
+        emit([var(Name), ' ', Text, ' ']),
         list(List, [last_connector(or)|Options])
     ).
 inlined_var(Var, Constraints, Options) -->
@@ -698,8 +700,12 @@ connector('.', _Options) -->
     emit([ span(class('full-stop'), '.')
          ]).
 
-human_connector(Term, String) :-
-    phrase(scasp_justification_message(Term), [String]).
+human_connector(Term, Connector) :-
+    phrase(scasp_justification_message(Term), List),
+    (   List = [Connector]
+    ->  true
+    ;   Connector = List
+    ).
 
 full_stop(_Options) -->
     emit('\u220e').                     % QED block

--- a/prolog/scasp/html.pl
+++ b/prolog/scasp/html.pl
@@ -419,26 +419,33 @@ utter(global_constraints_hold, _Options) -->
 utter(global_constraint(N), _Options) -->
     emit('the global constraint number ~p holds'-[N]).
 utter(not(Atom), Options) -->
-    emit('there is no evidence that '),
+    { human_connector(not, Text) },
+    emit(Text),
     atom(Atom, Options).
 utter(-(Atom), Options) -->
-    emit('it is not the case that '),
+    { human_connector(-, Text) },
+    emit(Text),
     atom(Atom, Options).
 utter(proved(Atom), Options) -->
+    { human_connector(proved, Text) },
     atom(Atom, Options),
-    emit(', justified above').
+    emit(Text).
 utter(chs(Atom), Options) -->
-    emit('it is assumed that '),
+    { human_connector(chs, Text) },
+    emit(Text),
     atom(Atom, Options).
 utter(assume(Atom), Options) -->
-    emit('we assume that '),
+    { human_connector(assume, Text) },
+    emit(Text),
     atom(Atom, Options).
 utter(holds(Atom), Options) -->
     { css_classes(Options, Classes) },
     (   { atom(Atom) }
-    ->  emit([span(class(Classes), Atom), ' holds'])
+    ->  { human_connector(holds, Text) },
+        emit([span(class(Classes), Atom), Text])
     ;   { Atom =.. [Name|Args] }
-    ->  emit([span(class(Classes), Name), ' holds for ']),
+    ->  { human_connector(holds_for, Text) },
+        emit([span(class(Classes), Name), Text]),
         list(Args, Options)
     ).
 

--- a/prolog/scasp/html.pl
+++ b/prolog/scasp/html.pl
@@ -52,6 +52,9 @@ user:file_search_path(css, library(scasp/web/css)).
 %
 %     - pred(Boolean)
 %       When `false` (default `true`), ignore user pred/1 rules.
+%     - justify_nmr(Boolean)
+%       When `false` (default `true`), do not omit a justification for
+%       the global constraints.
 
 :- det(html_justification_tree//2).
 
@@ -120,6 +123,9 @@ normal_justification_tree(Term-[], Options) -->
                     \connect(Options)
                   ])
             ])).
+normal_justification_tree(o_nmr_check-_, Options) -->
+    { option(justify_nmr(false), Options) },
+    !.
 normal_justification_tree(Term-Children, Options) -->
     { incr_indent(Options, Options1),
       (   Term == o_nmr_check

--- a/prolog/scasp/html.pl
+++ b/prolog/scasp/html.pl
@@ -550,9 +550,9 @@ inlined_var(Var, Constraints, Options) -->
 
 clpq(Var, [Constraint|More], Options) -->
     { compound(Constraint),
-      Constraint =.. [Op,A,B],
+      Constraint =.. [_,A,B],
       Var == A,
-      cmp_op(Op, Text),
+      human_connector(Constraint, Text),
       (   nonvar(Var),
           Var = '$VAR'(Name)
       ->  Id = var(Name)
@@ -569,9 +569,9 @@ clpq(Var, [Constraint|More], Options) -->
 
 clpq_and([Constraint|More], Var, Options) -->
     { compound(Constraint),
-      Constraint =.. [Op,A,B],
+      Constraint =.. [_,A,B],
       A == Var,
-      cmp_op(Op, Text)
+      human_connector(Constraint, Text)
     },
     emit([Text, ' ']),
     scasp_term(B, Options),
@@ -580,14 +580,6 @@ clpq_and([Constraint|More], Var, Options) -->
     ;   emit(' and '),
         clpq_and(More, Var, Options)
     ).
-
-cmp_op(#>,  'larger than').
-cmp_op(#>=, 'larger than or equal to').
-cmp_op(#<,  'smaller than').
-cmp_op(#=<, 'smaller than or equal to').
-cmp_op(#=,  'equal to').
-cmp_op(#<>, 'not equal to').
-
 
 %!  typed_var(@Var, +Type, +Options)//
 

--- a/prolog/scasp/input.pl
+++ b/prolog/scasp/input.pl
@@ -193,6 +193,9 @@ add_statements(New, Tail, [New|Tail]).
 
 :- det(sasp_statement/5).
 
+sasp_statement(clause(Ref, Term), VarNames, clause(Ref, SASP), Pos, Options) :-
+    !,
+    sasp_statement(Term, VarNames, SASP, Pos, Options).
 sasp_statement(Term, VarNames, SASP, Pos, Options) :-
     maplist(bind_var,VarNames),
     term_variables(Term, Vars),

--- a/prolog/scasp/input.pl
+++ b/prolog/scasp/input.pl
@@ -202,7 +202,7 @@ sasp_statement(clause(Ref, Term), VarNames, clause(Ref, SASP), Pos, Options) :-
     sasp_statement_(Term, VarNames, SASP, Pos, Options).
 sasp_statement(source(Path, Term), VarNames, source(Path, Pos, SASP), Pos, Options) :-
     !,
-    sasp_statement_(Term, VarNames, SASP, Pos, Options).
+    sasp_statement_(Term, VarNames, SASP, Pos, [source(Path-Pos)|Options]).
 sasp_statement_(Term, VarNames, SASP, Pos, Options) :-
     maplist(bind_var,VarNames),
     term_variables(Term, Vars),
@@ -370,17 +370,18 @@ directive(pred(Pred::Template), Statements, Pos, Options) =>
     Statements = (:- pred(SASPPred::Template)).
 directive(abducible(Pred), Rules, Pos, Options) =>
     sasp_predicate(Pred, ASPPred, Pos, Options),
-    abducible_rules(ASPPred, Rules).
+    abducible_rules(ASPPred, Rules, Options).
 directive(Directive, Statements, Pos, Options) =>
     sasp_syntax_error(invalid_directive(Directive), Pos, Options),
     Statements = [].
 
 abducible_rules(Head,
-                [ Head                 - [ not AHead, abducible_1(Head) ],
-                  AHead                - [ not Head ],
-                  abducible_1(Head)    - [ not '_abducible_1'(Head) ],
-                  '_abducible_1'(Head) - [ not abducible_1(Head) ]
-                ]) :-
+                [ source(Path, Pos, Head                 - [ not AHead, abducible_1(Head) ]),
+                  source(Path, Pos, AHead                - [ not Head                     ]),
+                  source(Path, Pos, abducible_1(Head)    - [ not '_abducible_1'(Head)     ]),
+                  source(Path, Pos, '_abducible_1'(Head) - [ not abducible_1(Head)        ])
+                ], Options) :-
+    option(source(Path-Pos), Options, no_path-no_position),
     Head =.. [F|Args],
     atom_concat('_', F, AF),
     AHead =.. [AF|Args].

--- a/prolog/scasp/lang/en.pl
+++ b/prolog/scasp/lang/en.pl
@@ -2,6 +2,7 @@
           [ scasp_message//1
           ]).
 :- use_module(library(dcg/high_order)).
+:- use_module('../ops', [op(_,_,_)]).
 
 :- multifile
     scasp_messages:scasp_lang_module/2.
@@ -111,6 +112,12 @@ scasp_message(_>_)       --> ['is greater than'].
 scasp_message(_>=_)      --> ['is greater than or equal to'].
 scasp_message(_<_)       --> ['is less than'].
 scasp_message(_=<_)      --> ['is less than or equal to'].
+scasp_message(_#=_)      --> ['equal to'].
+scasp_message(_#<>_)     --> ['not equal to'].
+scasp_message(_#>_)      --> ['greater than'].
+scasp_message(_#>=_)     --> ['greater than or equal to'].
+scasp_message(_#<_)      --> ['less than'].
+scasp_message(_#=<_)     --> ['less than or equal to'].
 scasp_message(global_constraints_hold) -->
     [ 'The global constraints hold' ].
 scasp_message(global_constraint(N)) -->

--- a/prolog/scasp/lang/en.pl
+++ b/prolog/scasp/lang/en.pl
@@ -94,16 +94,23 @@ scasp_message(no_models(CPU)) -->
 
 % Justifications
 
-scasp_message(and)       --> [ ', and' ].
-scasp_message(not)       --> [ 'there is no evidence that ' ].
-scasp_message(-)         --> [ 'it is not the case that ' ].
-scasp_message(implies)   --> [ ', because' ].
+scasp_message(and)       --> [ 'and' ].
+scasp_message(or)        --> [ 'or' ].
+scasp_message(not)       --> [ 'there is no evidence that' ].
+scasp_message(-)         --> [ 'it is not the case that' ].
+scasp_message(implies)   --> [ 'because' ].
 scasp_message(?)         --> [ '?' ].
-scasp_message(proved)    --> [', justified above'].
-scasp_message(chs)       --> ['it is assumed that '].
-scasp_message(assume)    --> ['we assume that '].
+scasp_message(proved)    --> ['justified above'].
+scasp_message(chs)       --> ['it is assumed that'].
+scasp_message(assume)    --> ['we assume that'].
 scasp_message(holds)     --> [' holds'].
 scasp_message(holds_for) --> [' holds for '].
+scasp_message(not_in)    --> [' not '].
+scasp_message(neq)       --> [' not equal to'].
+scasp_message(_>_)       --> ['is greater than'].
+scasp_message(_>=_)      --> ['is greater than or equal to'].
+scasp_message(_<_)       --> ['is less than'].
+scasp_message(_=<_)      --> ['is less than or equal to'].
 
 
 		 /*******************************

--- a/prolog/scasp/lang/en.pl
+++ b/prolog/scasp/lang/en.pl
@@ -105,12 +105,16 @@ scasp_message(chs)       --> ['it is assumed that'].
 scasp_message(assume)    --> ['we assume that'].
 scasp_message(holds)     --> [' holds'].
 scasp_message(holds_for) --> [' holds for '].
-scasp_message(not_in)    --> [' not '].
-scasp_message(neq)       --> [' not equal to'].
+scasp_message(not_in)    --> ['not'].
+scasp_message(neq)       --> ['not equal to'].
 scasp_message(_>_)       --> ['is greater than'].
 scasp_message(_>=_)      --> ['is greater than or equal to'].
 scasp_message(_<_)       --> ['is less than'].
 scasp_message(_=<_)      --> ['is less than or equal to'].
+scasp_message(global_constraints_hold) -->
+    [ 'The global constraints hold' ].
+scasp_message(global_constraint(N)) -->
+    [ 'the global constraint number ', N, ' holds' ].
 
 
 		 /*******************************

--- a/prolog/scasp/lang/en.pl
+++ b/prolog/scasp/lang/en.pl
@@ -146,7 +146,7 @@ print_stack([[]|As],I) -->
     !,
     { I1 is I - 4 },
     print_stack(As, I1).
-print_stack([A|As],I) -->
+print_stack([goal_origin(A, _)|As],I) -->
     ['~t~*|'-[I]], goal(A), [ nl ],
     { I1 is I + 4 },
     print_stack(As,I1).

--- a/prolog/scasp/lang/en.pl
+++ b/prolog/scasp/lang/en.pl
@@ -4,9 +4,9 @@
 :- use_module(library(dcg/high_order)).
 
 :- multifile
-    scasp_messages:scasp_lang/2.
+    scasp_messages:scasp_lang_module/2.
 
-scasp_messages:scasp_lang(en, casp_lang_en).
+scasp_messages:scasp_lang_module(en, casp_lang_en).
 
 :- multifile
     prolog:error_message//1.
@@ -90,6 +90,20 @@ scasp_message(dcc_discard(Goal, BodyL)) -->
 
 scasp_message(no_models(CPU)) -->
     [ 'No models (~3f seconds)'-[CPU] ].
+
+
+% Justifications
+
+scasp_message(and)     --> [ ', and' ].
+scasp_message(not)     --> [ 'there is no evidence that ' ].
+scasp_message(-)       --> [ 'it is not the case that ' ].
+scasp_message(implies) --> [ ', because' ].
+scasp_message(?)       --> [ '?' ].
+
+
+		 /*******************************
+		 *       GOALS AND STACKS	*
+		 *******************************/
 
 print_check_calls_calling(Goal, Stack) -->
     [ansi(bold, '~`-t Calling: ~@ ~`-t~72|', [scasp_verbose:print_goal(Goal)]), nl],

--- a/prolog/scasp/lang/nl.pl
+++ b/prolog/scasp/lang/nl.pl
@@ -86,16 +86,23 @@ scasp_message(no_models(CPU)) -->
 
 % Justifications
 
-scasp_message(and)     --> [ ', en' ].
-scasp_message(not)     --> [ 'er is geen bewijs dat ' ].
-scasp_message(-)       --> [ 'het is niet het geval dat ' ].
-scasp_message(implies) --> [ ', omdat' ].
-scasp_message(?)       --> [ '?' ].
-scasp_message(proved)    --> [', als hierboven aangetoond'].
-scasp_message(chs)       --> ['Het is aangenomen dat '].
-scasp_message(assume)    --> ['We nemen aan dat '].
+scasp_message(and)       --> [ 'en' ].
+scasp_message(or)        --> [ 'of' ].
+scasp_message(not)       --> [ 'er is geen bewijs dat' ].
+scasp_message(-)         --> [ 'het is niet het geval dat' ].
+scasp_message(implies)   --> [ 'omdat' ].
+scasp_message(?)         --> [ '?' ].
+scasp_message(proved)    --> ['als hierboven aangetoond'].
+scasp_message(chs)       --> ['het is aangenomen dat'].
+scasp_message(assume)    --> ['we nemen aan dat'].
 scasp_message(holds)     --> [' is waar'].
 scasp_message(holds_for) --> [' is waar voor '].
+scasp_message(not_in)    --> [' niet zijnde '].
+scasp_message(neq)       --> [' ongelijk aan'].
+scasp_message(_>_)       --> ['is groter dan'].
+scasp_message(_>=_)      --> ['is groter dan of gelijk aan'].
+scasp_message(_<_)       --> ['is kleiner dan'].
+scasp_message(_=<_)      --> ['is kleiner dan of gelijk aan'].
 
 
 		 /*******************************

--- a/prolog/scasp/lang/nl.pl
+++ b/prolog/scasp/lang/nl.pl
@@ -1,4 +1,4 @@
-:- module(casp_lang_en,
+:- module(casp_lang_nl,
           [ scasp_message//1
           ]).
 :- use_module(library(dcg/high_order)).
@@ -6,53 +6,45 @@
 :- multifile
     scasp_messages:scasp_lang_module/2.
 
-scasp_messages:scasp_lang_module(en, casp_lang_en).
-
-:- multifile
-    prolog:error_message//1.
-
-prolog:error_message(existence_error(scasp_query, scasp_main)) -->
-    [ 'sCASP: the program does not contain a query'-[] ].
-prolog:error_message(existence_error(scasp_query, M)) -->
-    [ 'sCASP: no query in module ~p'-[M] ].
+scasp_messages:scasp_lang_module(nl, casp_lang_nl).
 
 
 		 /*******************************
-		 *            CASP		*
+		 *            SCASP		*
 		 *******************************/
 
 scasp_message(version(Version)) -->
-    [ 'version ~w'-[Version] ].
+    [ 'versie ~w'-[Version] ].
 
 % Usage messages
 
 scasp_message(source_not_found(Source)) -->
     (   \+ { access_file(Source, exist) }
-    ->  [ 'Input file '-[] ], code(Source), [ ' does not exist'-[] ]
-    ;   [ 'Cannot read input file '-[] ], code(Source)
+    ->  [ 'Invoer bestand '-[] ], code(Source), [ ' bestaat niet'-[] ]
+    ;   [ 'Kan invoer bestand '-[] ], code(Source), [ ' niet lezen'-[] ]
     ).
 scasp_message(no_input_files) -->
-    [ 'No input file specified!' ].
+    [ 'Geen invoer gespecificeerd!' ].
 scasp_message(no_query) -->
-    [ 'the program does not contain ?- Query.'-[] ].
+    [ 'Het programma bevat geen ?- Query.'-[] ].
 scasp_message(undefined_operator(Op)) -->
-    [ 'clp operator ~p not defined'-[Op] ].
+    [ 'clp operator ~p is niet gedefinieerd'-[Op] ].
 scasp_message(at_most_one_of([A,B])) -->
-    ['Options '], opt(A), [' and '], opt(B),
-    [' cannot be used together' ].
+    ['Opties '], opt(A), [' and '], opt(B),
+    [' gaan niet samen' ].
 scasp_message(at_most_one_of(List)) -->
-    [ 'At most one of the options '-[] ],
+    [ 'Maximaal een van de opties '-[] ],
     options(List),
-    [ ' is allowed.'-[] ].
+    [ ' kan gelijktijdig gebruikt worden.'-[] ].
 scasp_message(opt_dcc_prev_forall) -->
-    [ 'Option --dcc can only be used with --forall=prev' ].
+    [ 'Optie --dcc kan alleen samen met --forall=prev' ].
 scasp_message(opt_incompatible(Opt1, Opt2)) -->
-    [ 'Option ' ], opt(Opt1), [' is not compatible with '], opt(Opt2).
+    [ 'Optie ' ], opt(Opt1), [' gaat niet samen met '], opt(Opt2).
 
 % Solver messages
 
 scasp_message(failure_calling_negation(Goal)) -->
-    [ 'Failure calling negation of '-[] ], goal(Goal).
+    [ 'Negatie van '-[] ], goal(Goal), [ ' faalt'-[] ].
 scasp_message(co_failing_in_negated_loop(Goal, NegGoal)) -->
     [ 'Co-Failing in a negated loop due to a variant call'-[], nl,
       '(extension clp-disequality required).'-[]
@@ -89,21 +81,21 @@ scasp_message(dcc_discard(Goal, BodyL)) -->
 % Results
 
 scasp_message(no_models(CPU)) -->
-    [ 'No models (~3f seconds)'-[CPU] ].
+    [ 'Geen modellen (~3f seconden)'-[CPU] ].
 
 
 % Justifications
 
-scasp_message(and)       --> [ ', and' ].
-scasp_message(not)       --> [ 'there is no evidence that ' ].
-scasp_message(-)         --> [ 'it is not the case that ' ].
-scasp_message(implies)   --> [ ', because' ].
-scasp_message(?)         --> [ '?' ].
-scasp_message(proved)    --> [', justified above'].
-scasp_message(chs)       --> ['it is assumed that '].
-scasp_message(assume)    --> ['we assume that '].
-scasp_message(holds)     --> [' holds'].
-scasp_message(holds_for) --> [' holds for '].
+scasp_message(and)     --> [ ', en' ].
+scasp_message(not)     --> [ 'er is geen bewijs dat ' ].
+scasp_message(-)       --> [ 'het is niet het geval dat ' ].
+scasp_message(implies) --> [ ', omdat' ].
+scasp_message(?)       --> [ '?' ].
+scasp_message(proved)    --> [', als hierboven aangetoond'].
+scasp_message(chs)       --> ['Het is aangenomen dat '].
+scasp_message(assume)    --> ['We nemen aan dat '].
+scasp_message(holds)     --> [' is waar'].
+scasp_message(holds_for) --> [' is waar voor '].
 
 
 		 /*******************************

--- a/prolog/scasp/lang/nl.pl
+++ b/prolog/scasp/lang/nl.pl
@@ -2,6 +2,7 @@
           [ scasp_message//1
           ]).
 :- use_module(library(dcg/high_order)).
+:- use_module('../ops', [op(_,_,_)]).
 
 :- multifile
     scasp_messages:scasp_lang_module/2.
@@ -103,6 +104,12 @@ scasp_message(_>_)       --> ['is groter dan'].
 scasp_message(_>=_)      --> ['is groter dan of gelijk aan'].
 scasp_message(_<_)       --> ['is kleiner dan'].
 scasp_message(_=<_)      --> ['is kleiner dan of gelijk aan'].
+scasp_message(_#=_)      --> ['gelijk aan'].
+scasp_message(_#<>_)     --> ['ongelijk aan'].
+scasp_message(_#>_)      --> ['groter dan'].
+scasp_message(_#>=_)     --> ['groter dan of gelijk aan'].
+scasp_message(_#<_)      --> ['kleiner dan'].
+scasp_message(_#=<_)     --> ['kleiner dan of gelijk aan'].
 scasp_message(global_constraints_hold) -->
     [ 'Aan alle globale restricties is voldaan' ].
 scasp_message(global_constraint(N)) -->

--- a/prolog/scasp/lang/nl.pl
+++ b/prolog/scasp/lang/nl.pl
@@ -97,12 +97,17 @@ scasp_message(chs)       --> ['het is aangenomen dat'].
 scasp_message(assume)    --> ['we nemen aan dat'].
 scasp_message(holds)     --> [' is waar'].
 scasp_message(holds_for) --> [' is waar voor '].
-scasp_message(not_in)    --> [' niet zijnde '].
-scasp_message(neq)       --> [' ongelijk aan'].
+scasp_message(not_in)    --> ['niet zijnde'].
+scasp_message(neq)       --> ['ongelijk aan'].
 scasp_message(_>_)       --> ['is groter dan'].
 scasp_message(_>=_)      --> ['is groter dan of gelijk aan'].
 scasp_message(_<_)       --> ['is kleiner dan'].
 scasp_message(_=<_)      --> ['is kleiner dan of gelijk aan'].
+scasp_message(global_constraints_hold) -->
+    [ 'Aan alle globale restricties is voldaan' ].
+scasp_message(global_constraint(N)) -->
+    [ 'Aan de globale restrictie nummer ', N, ' is voldaan' ].
+
 
 
 		 /*******************************

--- a/prolog/scasp/listing.pl
+++ b/prolog/scasp/listing.pl
@@ -65,7 +65,7 @@ scasp_portray_program(M, Options) :-
           Query = []),
     MOptions = [module(M)|Options],
     VOptions = [variable_names(Bindings)|MOptions],
-    findall(rule(Head,Body), M:pr_rule(Head,Body), Rules),
+    findall(rule(Head,Body), M:pr_rule(_Origin, Head, Body), Rules),
     filter(Rules, UserRules0, DualRules, NMRChecks0),
     remove_nmr_checks(NMRChecks0, UserRules0, NMRChecks, UserRules),
     findall(rule(DccH,DccB), M:pr_dcc_predicate(DccH,DccB),DCCs),

--- a/prolog/scasp/listing.pl
+++ b/prolog/scasp/listing.pl
@@ -65,7 +65,7 @@ scasp_portray_program(M, Options) :-
           Query = []),
     MOptions = [module(M)|Options],
     VOptions = [variable_names(Bindings)|MOptions],
-    findall(rule(Head,Body), M:pr_rule(_Origin, Head, Body), Rules),
+    findall(rule(Head,Body), M:pr_rule(Head, Body, _Origin), Rules),
     filter(Rules, UserRules0, DualRules, NMRChecks0),
     remove_nmr_checks(NMRChecks0, UserRules0, NMRChecks, UserRules),
     findall(rule(DccH,DccB), M:pr_dcc_predicate(DccH,DccB),DCCs),

--- a/prolog/scasp/messages.pl
+++ b/prolog/scasp/messages.pl
@@ -3,6 +3,7 @@
             scasp_justification_message//1       % +Term
           ]).
 :- use_module(lang/en, []).
+:- use_module(lang/nl, []).                      % Dynamic?
 :- use_module(library(solution_sequences)).
 
 :- create_prolog_flag(scasp_lang, default, [keep(true)]).
@@ -46,10 +47,15 @@ scasp_lang(Lang),
     current_prolog_flag(scasp_lang, Lang0),
     Lang0 \== default =>
     Lang = Lang0.
+:- if(current_prolog_flag(windows, true)).
 scasp_lang(Lang),
-    \+ current_prolog_flag(windows, true),
-    setlocale(messages, Lang0, Lang0) =>
+    win_get_user_preferred_ui_languages(name, [Lang0|_]) =>
     Lang = Lang0.
+:- else.
+scasp_lang(Lang),
+    catch(setlocale(messages, Lang0, Lang0),_,fail) =>
+    Lang = Lang0.
+:- endif.
 scasp_lang(Lang),
     getenv('LANG', Lang0) =>
     Lang = Lang0.
@@ -61,9 +67,9 @@ longest_id(Lang, Id) :-
     longest_prefix(Components, Taken),
     atomic_list_concat(Taken, '_', Id).
 
-longest_prefix(List, List).
-longest_prefix([_|T], Prefix) :-
-    longest_prefix(T, Prefix).
+longest_prefix([H|T0], [H|T]) :-
+    longest_prefix(T0, T).
+longest_prefix(_, []).
 
 :- multifile
     prolog:message//1.

--- a/prolog/scasp/messages.pl
+++ b/prolog/scasp/messages.pl
@@ -3,6 +3,8 @@
 :- use_module(lang/en, []).
 :- use_module(library(solution_sequences)).
 
+:- create_prolog_flag(scasp_lang, default, [keep(true)]).
+
 :- multifile
     scasp_lang/2.
 
@@ -34,11 +36,23 @@ clean_encoding(Lang0, Lang) :-
     ;   Lang = Lang0
     ).
 
-msg_language(Lang) :-
+%!  msg_language(-Lang) is det.
+%
+%   Get the current language for messages.
+
+msg_language(Lang),
+    current_prolog_flag(scasp_lang, Lang0),
+    Lang0 \== default =>
+    Lang = Lang0.
+msg_language(Lang),
     \+ current_prolog_flag(windows, true),
-    setlocale(messages, Lang, Lang).
-msg_language(Lang) :-
-    getenv('LANG', Lang).
+    setlocale(messages, Lang0, Lang0) =>
+    Lang = Lang0.
+msg_language(Lang),
+    getenv('LANG', Lang0) =>
+    Lang = Lang0.
+msg_language(Lang) =>
+    Lang = en.
 
 longest_id(Lang, Id) :-
     split_string(Lang, "_-", "", Components),

--- a/prolog/scasp/messages.pl
+++ b/prolog/scasp/messages.pl
@@ -53,7 +53,9 @@ scasp_lang(Lang),
     Lang = Lang0.
 :- else.
 scasp_lang(Lang),
-    catch(setlocale(messages, Lang0, Lang0),_,fail) =>
+    catch(setlocale(messages, _, ''), _, fail) =>
+    setlocale(messages, Lang0, Lang0),
+    writeln(Lang0),
     Lang = Lang0.
 :- endif.
 scasp_lang(Lang),

--- a/prolog/scasp/messages.pl
+++ b/prolog/scasp/messages.pl
@@ -11,7 +11,7 @@
 :- multifile
     scasp_lang_module/2.
 
-:- dynamic lang_module_cache/1 as volatile.
+:- thread_local lang_module_cache/1 as volatile.
 
 %!  lang_module(-M) is multi.
 %

--- a/prolog/scasp/messages.pl
+++ b/prolog/scasp/messages.pl
@@ -1,12 +1,14 @@
 :- module(scasp_messages,
-          []).
+          [ scasp_lang/1,			 % -Lang
+            scasp_justification_message//1       % +Term
+          ]).
 :- use_module(lang/en, []).
 :- use_module(library(solution_sequences)).
 
 :- create_prolog_flag(scasp_lang, default, [keep(true)]).
 
 :- multifile
-    scasp_lang/2.
+    scasp_lang_module/2.
 
 :- dynamic lang_module_cache/1 as volatile.
 
@@ -23,12 +25,12 @@ lang_module(M) :-
     ).
 
 gen_lang_module(Module) :-
-    msg_language(Lang),
+    scasp_lang(Lang),
     clean_encoding(Lang, Clean),
     longest_id(Clean, LangID),
-    scasp_lang(LangID, Module).
+    scasp_lang_module(LangID, Module).
 gen_lang_module(Module) :-
-    scasp_lang(en, Module).
+    scasp_lang_module(en, Module).
 
 clean_encoding(Lang0, Lang) :-
     (   sub_atom(Lang0, A, _, _, '.')
@@ -36,22 +38,22 @@ clean_encoding(Lang0, Lang) :-
     ;   Lang = Lang0
     ).
 
-%!  msg_language(-Lang) is det.
+%!  scasp_lang(-Lang) is det.
 %
-%   Get the current language for messages.
+%   True when Lang is the language used for messages and justifications.
 
-msg_language(Lang),
+scasp_lang(Lang),
     current_prolog_flag(scasp_lang, Lang0),
     Lang0 \== default =>
     Lang = Lang0.
-msg_language(Lang),
+scasp_lang(Lang),
     \+ current_prolog_flag(windows, true),
     setlocale(messages, Lang0, Lang0) =>
     Lang = Lang0.
-msg_language(Lang),
+scasp_lang(Lang),
     getenv('LANG', Lang0) =>
     Lang = Lang0.
-msg_language(Lang) =>
+scasp_lang(Lang) =>
     Lang = en.
 
 longest_id(Lang, Id) :-
@@ -72,3 +74,8 @@ prolog:message(scasp(Term)) -->
     },
     Module:scasp_message(Term).
 
+scasp_justification_message(Term) -->
+    { lang_module(Module)
+    },
+    Module:scasp_message(Term),
+    !.

--- a/prolog/scasp/messages.pl
+++ b/prolog/scasp/messages.pl
@@ -55,7 +55,6 @@ scasp_lang(Lang),
 scasp_lang(Lang),
     catch(setlocale(messages, _, ''), _, fail) =>
     setlocale(messages, Lang0, Lang0),
-    writeln(Lang0),
     Lang = Lang0.
 :- endif.
 scasp_lang(Lang),

--- a/prolog/scasp/nmr_check.pl
+++ b/prolog/scasp/nmr_check.pl
@@ -77,14 +77,14 @@ Gopal Gupta, LOPSTR 2012 for details on the _NMR check_
 
 generate_nmr_check(M) :-
     debug(scasp(compile), 'Generating NMR check...', []),
-    findall(R, (defined_rule(_, H, B), c_rule(R, H, B)), Rs), % get all rules
+    findall(R, (defined_rule(_, H, B, _), c_rule(R, H, B)), Rs), % get all rules
     olon_rules(Rs, M, Rc),
     nmr_check(Rc, Nmrchk),
-    retractall(defined_rule('_false_0', _, _)), % remove headless rules
+    retractall(defined_rule('_false_0', _, _, _)), % remove headless rules
     negate_functor('_false_0', Nf),
     predicate(Np, Nf, []),
     c_rule(Nr, Np, []),
-    assert_rule(Nr), % assert fact for negation of dummy head.
+    assert_rule(nmr(Nr)), % assert fact for negation of dummy head.
     assert_nmr_check(Nmrchk).
 
 %!  nmr_check(+OLONrules:list, -NmrCheck:list) is det

--- a/prolog/scasp/pr_rules.pl
+++ b/prolog/scasp/pr_rules.pl
@@ -402,7 +402,7 @@ assert_pr_rules([], _).
 assert_pr_rules([c(Origin, Head, Body)|Rs], M) :-
     !,
     revar(Head-Body,H-B, _),
-    assert(M:pr_rule(Origin, H, B)),
+    assert(M:pr_rule(H, B, Origin)),
     assert_pr_user_predicate([H], M),
     assert_pr_rules(Rs, M).
 

--- a/prolog/scasp/predicates.pl
+++ b/prolog/scasp/predicates.pl
@@ -84,7 +84,7 @@ clp_interval(sup(_Expr, _Inf)).
 %
 %   True when Head is part of the transformed representation.
 
-scasp_compiled(pr_rule(_Head, _Body)).
+scasp_compiled(pr_rule(_Origin, _Head, _Body)).
 scasp_compiled(pr_query(_Query)).
 scasp_compiled(pr_user_predicate(_Pred)).
 scasp_compiled(pr_table_predicate(_Pred)).

--- a/prolog/scasp/predicates.pl
+++ b/prolog/scasp/predicates.pl
@@ -84,7 +84,7 @@ clp_interval(sup(_Expr, _Inf)).
 %
 %   True when Head is part of the transformed representation.
 
-scasp_compiled(pr_rule(_Origin, _Head, _Body)).
+scasp_compiled(pr_rule(_Head, _Body, _Origin)).
 scasp_compiled(pr_query(_Query)).
 scasp_compiled(pr_user_predicate(_Pred)).
 scasp_compiled(pr_table_predicate(_Pred)).

--- a/prolog/scasp/solve.pl
+++ b/prolog/scasp/solve.pl
@@ -359,7 +359,7 @@ exec_with_neg_list(Var, Goal, M, [Value|Vs],
 %   defined in the program using the directive _#table pred/n._
 
 solve_goal_table_predicate(Goal, M, Parents, ProvedIn, ProvedOut, AttStackIn, AttStackOut, AttModel) :-
-    M:pr_rule(Goal, Body),
+    M:pr_rule(_Origin, Goal, Body),
     AttStackIn ~> stack(StackIn),
     solve(Body, M, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model),
     AttStackOut <~ stack(StackOut),
@@ -373,7 +373,7 @@ solve_goal_table_predicate(Goal, M, Parents, ProvedIn, ProvedOut, AttStackIn, At
 
 solve_goal_predicate(Goal, M, Parents, ProvedIn, ProvedOut, StackIn, StackOut,
                      GoalModel) :-
-    M:pr_rule(Goal, Body),
+    M:pr_rule(_Origin, Goal, Body),
     solve(Body, M, Parents, ProvedIn, ProvedMid, StackIn, StackOut, BodyModel),
     add_proved(Goal, ProvedMid, ProvedOut),
     GoalModel = [Goal|BodyModel].

--- a/prolog/scasp/solve.pl
+++ b/prolog/scasp/solve.pl
@@ -359,7 +359,7 @@ exec_with_neg_list(Var, Goal, M, [Value|Vs],
 %   defined in the program using the directive _#table pred/n._
 
 solve_goal_table_predicate(Goal, M, Parents, ProvedIn, ProvedOut, AttStackIn, AttStackOut, AttModel) :-
-    M:pr_rule(_Origin, Goal, Body),
+    M:pr_rule(Goal, Body, _Origin),
     AttStackIn ~> stack(StackIn),
     solve(Body, M, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model),
     AttStackOut <~ stack(StackOut),
@@ -373,7 +373,7 @@ solve_goal_table_predicate(Goal, M, Parents, ProvedIn, ProvedOut, AttStackIn, At
 
 solve_goal_predicate(Goal, M, Parents, ProvedIn, ProvedOut, StackIn, StackOut,
                      GoalModel) :-
-    M:pr_rule(_Origin, Goal, Body),
+    M:pr_rule(Goal, Body, _Origin),
     solve(Body, M, Parents, ProvedIn, ProvedMid, StackIn, StackOut, BodyModel),
     add_proved(Goal, ProvedMid, ProvedOut),
     GoalModel = [Goal|BodyModel].

--- a/prolog/scasp/solve.pl
+++ b/prolog/scasp/solve.pl
@@ -1,5 +1,6 @@
 :- module(scasp_solve,
-          [ solve/4                   % :Goals, +StackIn, -StackOut, -Model
+          [ solve/4,                  % :Goals, +StackIn, -StackOut, -Model
+            solve/5                   % :Goals, +Origin, +StackIn, -StackOut, -Model
           ]).
 :- use_module(clp/call_stack).
 :- use_module(predicates).
@@ -27,17 +28,20 @@
 %   the sub-goals.
 
 solve(M:Goals, StackIn, StackOut, Model) :-
+    solve(M:Goals, query, StackIn, StackOut, Model).
+solve(M:Goals, Origin, StackIn, StackOut, Model) :-
     stack_parents(StackIn, Parents),
     stack_proved(StackIn, ProvedIn),
-    solve(Goals, M, Parents, ProvedIn, _ProvedOout, StackIn, StackOut, Model).
+    solve(Goals, M, Origin, Parents, ProvedIn, _ProvedOout, StackIn, StackOut, Model).
 
-solve([], _, _, Proved, Proved, StackIn, [[]|StackIn], []).
-solve([Goal|Goals], M, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model) :-
+solve([], _, _, _, Proved, Proved, StackIn, [[]|StackIn], []).
+solve([Goal|Goals], M, Origin, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model) :-
     verbose(print_check_calls_calling(Goal, StackIn)),
-    check_goal(Goal, M, Parents, ProvedIn, ProvedMid, StackIn, StackMid, Modelx),
+    check_goal(Goal, M, Origin, Parents, ProvedIn, ProvedMid, StackIn, StackMid, Modelx),
+    verbose(format('Check ~@\n', [print_goal(Goal)])),
     Modelx = [AddGoal|JGoal],
     verbose(format('Success ~@\n', [print_goal(Goal)])),
-    solve(Goals, M, Parents, ProvedMid, ProvedOut, StackMid, StackOut, Modelxs),
+    solve(Goals, M, Origin, Parents, ProvedMid, ProvedOut, StackMid, StackOut, Modelxs),
     Modelxs = JGoals,
     (   shown_predicate(M:Goal)
     ->  Model = [AddGoal, JGoal|JGoals]
@@ -51,7 +55,7 @@ proved_relatives(Goal, Proved, Relatives) =>
     functor(Goal, Name, Arity),
     get_assoc(Name/Arity, Proved, Relatives).
 
-%!  check_goal(+Goal, +Module, +Parents, +ProvedIn, -ProvedOut,
+%!  check_goal(+Goal, +Module, +Origin, +Parents, +ProvedIn, -ProvedOut,
 %!              +StackIn, -StackOut, -Model)
 %
 %   Call  check_CHS/3 to  check the  sub-goal Goal  against the  list of
@@ -66,9 +70,9 @@ proved_relatives(Goal, Proved, Relatives) =>
 %	  - [], proved(Goal)		Proved in a completed subtree
 %	  - From solve_goal/5		Continued execution
 
-check_goal(Goal, M, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model) :-
+check_goal(Goal, M, Origin, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model) :-
     check_CHS(Goal, M, Parents, ProvedIn, StackIn, Check),
-    check_goal_(Check, Goal, M,
+    check_goal_(Check, Goal, M, Origin,
                 Parents, ProvedIn, ProvedOut, StackIn, StackOut,
                 Model),
     (   current_prolog_flag(scasp_dcc, true),
@@ -80,39 +84,39 @@ check_goal(Goal, M, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model) :-
     ).
 
 % coinduction success <- cycles containing even loops may succeed
-check_goal_(co_success, Goal, _M,
+check_goal_(co_success, Goal, _M, Origin,
             _Parents, ProvedIn, ProvedOut, StackIn, StackOut,
             [AddGoal]) :-
     AddGoal = chs(Goal),
     add_proved(AddGoal, ProvedIn, ProvedOut),
     (   current_prolog_flag(scasp_assume, true)
-    ->  mark_prev_goal(Goal,StackIn, StackMark),
-        StackOut = [[],AddGoal|StackMark]
-    ;   StackOut = [[],AddGoal|StackIn]
+    ->  mark_prev_goal(Goal, Origin, StackIn, StackMark),
+        StackOut = [[],goal_origin(AddGoal, Origin)|StackMark]
+    ;   StackOut = [[],goal_origin(AddGoal, Origin)|StackIn]
     ).
 % already proved in the stack
-check_goal_(proved, Goal, _M,
+check_goal_(proved, Goal, _M, Origin,
             _Parents, ProvedIn, ProvedOut, StackIn, StackOut,
             [AddGoal]) :-
     AddGoal = proved(Goal),
     add_proved(AddGoal, ProvedIn, ProvedOut),
-    StackOut = [[], proved(Goal)|StackIn].
+    StackOut = [[], goal_origin(proved(Goal), Origin)|StackIn].
 % coinduction does neither success nor fails <- the execution continues inductively
-check_goal_(cont, Goal, M,
+check_goal_(cont, Goal, M, Origin,
             Parents, ProvedIn, ProvedOut, StackIn, StackOut,
             Model) :-
-    solve_goal(Goal, M,
+    solve_goal(Goal, M, Origin,
                [Goal|Parents], ProvedIn, ProvedOut, StackIn, StackOut,
                Model).
 % coinduction fails <- the negation of a call unifies with a call in the call stack
-check_goal_(co_failure, _Goal, _M,
+check_goal_(co_failure, _Goal, _M, _Origin,
             _Parents, _ProvedIn, _ProvedOut, _StackIn, _StackOut,
             _Model) :-
     fail.
 
-mark_prev_goal(Goal,[I|In],[assume(Goal)|In]) :- Goal == I, !.
-mark_prev_goal(Goal,[I|In],[I|Mk]) :- mark_prev_goal(Goal,In,Mk).
-mark_prev_goal(_Goal,[],[]).
+mark_prev_goal(Goal, Origin, [I|In], [goal_origin(assume(Goal), Origin)|In]) :- Goal == I, !.
+mark_prev_goal(Goal, Origin, [I|In], [goal_origin(I, Origin)|Mk]) :- mark_prev_goal(Goal,Origin,In,Mk).
+mark_prev_goal(_Goal,_Origin,[],[]).
 
 %!  dynamic_consistency_check(+Goal, +Module, +StackIn) is semidet.
 %
@@ -137,15 +141,15 @@ dynamic_consistency_eval([SubGoal|Bs], M, StackIn) :-
 
 dynamic_consistency_eval_(not(SubGoal), M, StackIn) :-
     user_predicate(M:SubGoal), !,
-    member(not(SubGoal), StackIn).
+    member_stack(not(SubGoal), StackIn).
 dynamic_consistency_eval_(SubGoal, M, StackIn) :-
     user_predicate(M:SubGoal), !,
-    member(SubGoal, StackIn).
+    member_stack(SubGoal, StackIn).
 dynamic_consistency_eval_(SubGoal, _, _) :-
     solve_goal_builtin(SubGoal, _).
 
 
-%!  solve_goal(+Goal, +Module,
+%!  solve_goal(+Goal, +Module, +Origin,
 %!             +Parents, +ProvedIn, -ProvedOut, +StackIn, -StackOut,
 %!             -Model)
 %
@@ -154,20 +158,20 @@ dynamic_consistency_eval_(SubGoal, _, _) :-
 %   prove  the  sub-goals  and  in  `Model` the  model with  support the
 %   sub-goals
 
-solve_goal(Goal, M, Parents, ProvedIn, ProvedOut, StackIn, StackOut, GoalModel) :-
+solve_goal(Goal, M, Origin, Parents, ProvedIn, ProvedOut, StackIn, StackOut, GoalModel) :-
     Goal = forall(_, _),
     !,
     (   current_prolog_flag(scasp_forall, prev)
-    ->  solve_goal_forall(Goal, M,
-                          Parents, ProvedIn, ProvedOut, [Goal|StackIn], StackOut,
+    ->  solve_goal_forall(Goal, M, Origin,
+                          Parents, ProvedIn, ProvedOut, [goal_origin(Goal, Origin)|StackIn], StackOut,
                           Model)
-    ;   solve_c_forall(Goal, M,
-                       Parents, ProvedIn, ProvedOut, [Goal|StackIn], StackOut,
+    ;   solve_c_forall(Goal, M, Origin,
+                       Parents, ProvedIn, ProvedOut, [goal_origin(Goal, Origin)|StackIn], StackOut,
                        Model)
     ),
     GoalModel = [Goal|Model].
-solve_goal(Goal, _M,
-           _Parents, ProvedIn, ProvedOut, StackIn, [[], Goal|StackIn],
+solve_goal(Goal, _M, Origin,
+           _Parents, ProvedIn, ProvedOut, StackIn, [[], goal_origin(Goal, Origin)|StackIn],
            GoalModel) :-
     Goal = not(is(V, Expresion)),
     add_proved(Goal, ProvedIn, ProvedOut),
@@ -175,56 +179,56 @@ solve_goal(Goal, _M,
     NV is Expresion,
     V .\=. NV,
     GoalModel = [Goal].
-solve_goal(Goal, _, _, _, _, _, _, _) :-
+solve_goal(Goal, _, _, _, _, _, _, _, _) :-
     Goal = not(true),
     !,
     fail.
-solve_goal(Goal, M, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model) :-
+solve_goal(Goal, M, Origin, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model) :-
     table_predicate(M:Goal),
     !,
     verbose(format('Solve the tabled goal ~p\n', [Goal])),
-    AttStackIn <~ stack([Goal|StackIn]),
+    AttStackIn <~ stack([goal_origin(Goal, Origin)|StackIn]),
     solve_goal_table_predicate(Goal, M, Parents, ProvedIn, ProvedOut,
                                AttStackIn, AttStackOut, AttModel),
     AttStackOut ~> stack(StackOut),
     AttModel ~> model(Model).
-solve_goal(call(Goal), M, Parents, ProvedIn, ProvedOut, StackIn, StackOut,
+solve_goal(call(Goal), M, Origin, Parents, ProvedIn, ProvedOut, StackIn, StackOut,
            [call(Goal)|Model]) :-
     !,
-    solve_goal(Goal, M, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model).
-solve_goal(not(call(Goal)), M, Parents, ProvedIn, ProvedOut, StackIn, StackOut,
+    solve_goal(Goal, M, Origin, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model).
+solve_goal(not(call(Goal)), M, Origin, Parents, ProvedIn, ProvedOut, StackIn, StackOut,
            [not(call(Goal))|Model]) :-
     !,
-    solve_goal(not(Goal), M, Parents, ProvedIn, ProvedOut, StackIn, StackOut,
+    solve_goal(not(Goal), M, Origin, Parents, ProvedIn, ProvedOut, StackIn, StackOut,
                Model).
-solve_goal(Goal, M, Parents, ProvedIn, ProvedOut, StackIn, StackOut,
+solve_goal(Goal, M, Origin, Parents, ProvedIn, ProvedOut, StackIn, StackOut,
            [Goal|Model]) :-
     Goal = findall(_, _, _),
     !,
-    exec_findall(Goal, M, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model).
-solve_goal(not(Goal), M, Parents, ProvedIn, ProvedIn, StackIn, StackIn,
+    exec_findall(Goal, M, Origin, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model).
+solve_goal(not(Goal), M, Origin, Parents, ProvedIn, ProvedIn, StackIn, StackIn,
            [not(Goal)]) :-
     Goal = findall(_, _, _),
     !,
-    exec_neg_findall(Goal, M, Parents, ProvedIn, StackIn).
-solve_goal(Goal, M, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model) :-
+    exec_neg_findall(Goal, M, Origin, Parents, ProvedIn, StackIn).
+solve_goal(Goal, M, Origin, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model) :-
     user_predicate(M:Goal),
     !,
     (   solve_goal_predicate(Goal, M, Parents, ProvedIn, ProvedOut,
-                             [Goal|StackIn], StackOut, Model)
+                             [goal_origin(Goal, NewOrigin)|StackIn], StackOut, Model, NewOrigin)
     *-> true
     ;   verbose(format(' FAIL~n')),
         shown_predicate(M:Goal),
         scasp_trace(scasp_trace_failures,
-                    trace_failure(Goal, [Goal|StackIn])),
+                    trace_failure(Goal, [goal_origin(Goal, Origin)|StackIn])),
         fail
     ).
-solve_goal(Goal, _M, _Parents, ProvedIn, ProvedIn, StackIn, [[], Goal|StackIn],
+solve_goal(Goal, _M, _Origin, _Parents, ProvedIn, ProvedIn, StackIn, [[], Goal|StackIn],
            Model) :-
     solve_goal_builtin(Goal, Model).
 
 
-%!  solve_goal_forall(+Forall, +Module,
+%!  solve_goal_forall(+Forall, +Module, +Origin,
 %!                    +Parents, +ProvedIn, -ProvedOut, +StackIn, -StackOut,
 %!                    -Model)
 %
@@ -233,12 +237,12 @@ solve_goal(Goal, _M, _Parents, ProvedIn, ProvedIn, StackIn, [[], Goal|StackIn],
 %
 %   @arg Forall is a term forall(?Var, ?Goal)
 
-solve_goal_forall(forall(Var, Goal), M,
+solve_goal_forall(forall(Var, Goal), M, Origin,
                   Parents, ProvedIn, ProvedOut, StackIn, [[]|StackOut],
                   Model) :-
     my_copy_term(Var, Goal, NewVar, NewGoal),
     my_copy_term(Var, Goal, NewVar2, NewGoal2),
-    solve([NewGoal], M, Parents, ProvedIn, ProvedMid, StackIn, [[]|StackMid],
+    solve([NewGoal], M, Origin, Parents, ProvedIn, ProvedMid, StackIn, [[]|StackMid],
           ModelMid),
     verbose(format('\tSuccess solve ~@\n\t\t for the ~@\n',
                    [print_goal(NewGoal), print_goal(forall(Var, Goal))])),
@@ -257,7 +261,7 @@ solve_goal_forall(forall(Var, Goal), M,
                 DualList),
         verbose(format('Executing ~@ with clpq ConstraintList = ~p\n',
                        [print_goal(Goal), DualList])),
-        exec_with_clpq_constraints(NewVar2, NewGoal2, M,
+        exec_with_clpq_constraints(NewVar2, NewGoal2, M, Origin,
                                    entry(NewVar3, []),
                                    DualList,
                                    Parents, ProvedMid, ProvedOut,
@@ -267,7 +271,7 @@ solve_goal_forall(forall(Var, Goal), M,
     ;   !,   %% Position of the cut in s(CASP) - remove answers in max.lp
         verbose(format('Executing ~@ with clp_disequality list = ~p\n',
                        [print_goal(Goal), List])),
-        exec_with_neg_list(NewVar2, NewGoal2, M,
+        exec_with_neg_list(NewVar2, NewGoal2, M, Origin,
                            List, Parents, ProvedMid, ProvedOut,
                            StackMid, StackOut, ModelList),
         % !, %% Position of the cut in s(ASP) - remove answers in hamcycle_two.lp
@@ -285,9 +289,9 @@ check_unbound(Var, 'clpq'(NewVar, Constraints)) :-
 check_unbound(Var, []) :-
     var(Var), !.
 
-exec_with_clpq_constraints(_Var, _Goal, _M, _, [],
+exec_with_clpq_constraints(_Var, _Goal, _M, _Origin, _, [],
                            _Parents, ProvedIn, ProvedIn, StackIn, StackIn, []).
-exec_with_clpq_constraints(Var, Goal, M, entry(ConVar, ConEntry),
+exec_with_clpq_constraints(Var, Goal, M, Origin, entry(ConVar, ConEntry),
                            [dual(ConVar, ConDual)|Duals],
                            Parents, ProvedIn, ProvedOut, StackIn, StackOut,
                            Model) :-
@@ -301,7 +305,7 @@ exec_with_clpq_constraints(Var, Goal, M, entry(ConVar, ConEntry),
     (   apply_clpq_constraints(Con)
     ->  verbose(format('Executing ~p with clpq_constrains ~p\n',
                        [Goal01, Con])),
-        solve([Goal01], M, Parents01, ProvedIn01, ProvedOut01, StackIn01, [[]|StackOut01], Model01),
+        solve([Goal01], M, Origin, Parents01, ProvedIn01, ProvedOut01, StackIn01, [[]|StackOut01], Model01),
         verbose(format('Success executing ~p with constrains ~p\n',
                        [Goal01, Con])),
         verbose(format('Check entails Var = ~p with const ~p and ~p\n',
@@ -317,7 +321,7 @@ exec_with_clpq_constraints(Var, Goal, M, entry(ConVar, ConEntry),
                     DualList),
             verbose(format('Executing ~p with clpq ConstraintList = ~p\n',
                            [Goal, DualList])),
-            exec_with_clpq_constraints(Var, Goal, M, entry(ConVar01, Con01),
+            exec_with_clpq_constraints(Var, Goal, M, Origin, entry(ConVar01, Con01),
                                        DualList,
                                        Parents01, ProvedOut01, ProvedOut02,
                                        StackOut01, StackOut02, Model02),
@@ -331,24 +335,24 @@ exec_with_clpq_constraints(Var, Goal, M, entry(ConVar, ConEntry),
     ),
     verbose(format('Executing ~p with clpq ConstraintList = ~p\n',
                    [Goal, Duals])),
-    exec_with_clpq_constraints(Var02, Goal02, M,
+    exec_with_clpq_constraints(Var02, Goal02, M, Origin,
                                entry(ConVar02, ConEntry02),
                                Duals, Parents, ProvedOut02, ProvedOut,
                                StackOut02, StackOut, Model04),
     append(Model03, Model04, Model).
 
-exec_with_neg_list(_, _, _, [], _, ProvedIn, ProvedIn, StackIn, StackIn, []).
-exec_with_neg_list(Var, Goal, M, [Value|Vs],
+exec_with_neg_list(_, _, _, _, [], _, ProvedIn, ProvedIn, StackIn, StackIn, []).
+exec_with_neg_list(Var, Goal, M, Origin, [Value|Vs],
                    Parents, ProvedIn, ProvedOut, StackIn, StackOut,
                    Model) :-
     my_copy_term(Var, [Goal, StackIn], NewVar, [NewGoal, NewStackIn]),
     NewVar = Value,
     verbose(format('Executing ~p with value ~p\n', [NewGoal, Value])),
-    solve([NewGoal], M, Parents,
+    solve([NewGoal], M, Origin, Parents,
           ProvedIn, ProvedMid, NewStackIn, [[]|NewStackMid], ModelMid),
     verbose(format('Success executing ~p with value ~p\n',
                    [NewGoal, Value])),
-    exec_with_neg_list(Var, Goal, M, Vs, Parents,
+    exec_with_neg_list(Var, Goal, M, Origin, Vs, Parents,
                        ProvedMid, ProvedOut, NewStackMid, StackOut, Models),
     append(ModelMid, Models, Model).
 
@@ -359,22 +363,22 @@ exec_with_neg_list(Var, Goal, M, [Value|Vs],
 %   defined in the program using the directive _#table pred/n._
 
 solve_goal_table_predicate(Goal, M, Parents, ProvedIn, ProvedOut, AttStackIn, AttStackOut, AttModel) :-
-    M:pr_rule(Goal, Body, _Origin),
+    M:pr_rule(Goal, Body, Origin),
     AttStackIn ~> stack(StackIn),
-    solve(Body, M, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model),
+    solve(Body, M, Origin, Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model),
     AttStackOut <~ stack(StackOut),
     AttModel <~ model([Goal|Model]).
 
 %!  solve_goal_predicate(+Goal, +Module,
 %!                       +Parents, +ProvedIn, -ProvedOut, +StackIn, -StackOut,
-%!                       -Model)
+%!                       -Model, -Origin)
 %
 %   Used to evaluate a user predicate
 
 solve_goal_predicate(Goal, M, Parents, ProvedIn, ProvedOut, StackIn, StackOut,
-                     GoalModel) :-
-    M:pr_rule(Goal, Body, _Origin),
-    solve(Body, M, Parents, ProvedIn, ProvedMid, StackIn, StackOut, BodyModel),
+                     GoalModel, Origin) :-
+    M:pr_rule(Goal, Body, Origin),
+    solve(Body, M, Origin, Parents, ProvedIn, ProvedMid, StackIn, StackOut, BodyModel),
     add_proved(Goal, ProvedMid, ProvedOut),
     GoalModel = [Goal|BodyModel].
 
@@ -433,19 +437,15 @@ exec_goal(Goal) :-
 % TODO: Pending StackOut to carry the literal involved in the findall
 % (if needed)
 % TODO: Handling of ProvedIn/ProvedOut
-exec_findall(findall(Var, Call, List), M,
+exec_findall(findall(Var, Call, List), M, Origin,
              Parents, ProvedIn, ProvedOut, StackIn, StackOut, Model) :-
-
     verbose(format('execution of findall(~p, ~p, _) \n', [Var, Call])),
-
     findall(t(Var, S, M), (
-            solve([Call], M, Parents, ProvedIn, ProvedOut, StackIn, S0, M),
+            solve([Call], M, Origin, Parents, ProvedIn, ProvedOut, StackIn, S0, M),
             append(S, StackIn, S0)
         ), VSMList),
-
     process_vsmlist(VSMList, List, SOut, Model),
-    append(SOut, [findall(Var, Call, List)|StackIn], StackOut),
-
+    append(SOut, [goal_origin(findall(Var, Call, List), Origin)|StackIn], StackOut),
     verbose(format('Result execution = ~p \n', [List])).
 
 process_vsmlist(VSMList, List, [[]|StackOut], Model) :-
@@ -458,7 +458,7 @@ process_vsmlist_([t(V, [[]|S], M)|Rs], [V|Vs], S1, M1) :-
     append(M, M0, M1).
 
 % TODO: What to do with the negation of findall/3 (if required)
-exec_neg_findall(Goal, _, _, _, _) :-
+exec_neg_findall(Goal, _, _, _, _, _) :-
     verbose(format('PENDING: execution of not ~p \n', [Goal])),
     fail.
 
@@ -689,7 +689,7 @@ stack_parents([_|T], N, Parents) :-
     !,
     N1 is N+1,
     stack_parents(T, N1, Parents).
-stack_parents([H|T], N, [H|TP]) :-
+stack_parents([goal_origin(H)|T], N, [H|TP]) :-
     stack_parents(T, N, TP).
 
 %!  stack_proved(Stack, Proved:assoc) is det.
@@ -721,6 +721,8 @@ stack_proved([Top|Ss], Intervening, MaxInter, Proved0, Proved) :-
         stack_proved(Ss, Intervening, MaxInter, Proved1, Proved)
     ).
 
+add_proved(goal_origin(Goal, _), Assoc0, Assoc) :-
+    add_proved(Goal, Goal, Assoc0, Assoc).
 add_proved(Goal, Assoc0, Assoc) :-
     add_proved(Goal, Goal, Assoc0, Assoc).
 
@@ -737,7 +739,7 @@ add_proved(Term, Goal, Assoc0, Assoc) =>
     ;   put_assoc(Name/Arity, Assoc0, [Goal], Assoc)
     ).
 
-%!  solve_c_forall(+Forall, +Module,
+%!  solve_c_forall(+Forall, +Module, +Origin,
 %!                 +Parents, +ProvedIn, -ProvedOut, +StackIn, -StackOut,
 %!                 -Model)
 %
@@ -749,7 +751,7 @@ add_proved(Term, Goal, Assoc0, Assoc) =>
 %   @tbd Improve the efficiency by removing redundant justifications w.o.
 %   losing solutions.
 
-solve_c_forall(Forall, M, Parents, ProvedIn, ProvedOut, StackIn, [[]|StackOut],
+solve_c_forall(Forall, M, Origin, Parents, ProvedIn, ProvedOut, StackIn, [[]|StackOut],
                Model) :-
     collect_vars(Forall, c_forall(Vars0, Goal0)),    % c_forall([F,G], not q_1(F,G))
 
@@ -759,17 +761,17 @@ solve_c_forall(Forall, M, Parents, ProvedIn, ProvedOut, StackIn, [[]|StackOut],
     my_diff_term(Goal1, Vars1, OtherVars),
     Initial_Const = [],                              % Constraint store = top
     (   current_prolog_flag(scasp_forall, all)
-    ->  solve_var_forall_(Goal1, M, Parents, ProvedIn, ProvedOut,
+    ->  solve_var_forall_(Goal1, M, Origin, Parents, ProvedIn, ProvedOut,
                           entry(Vars1, Initial_Const),
                           dual(Vars1, [Initial_Const]),
                           OtherVars, StackIn, StackOut, Model)
-    ;   solve_other_forall(Goal1, M, Parents, ProvedIn, ProvedOut,
+    ;   solve_other_forall(Goal1, M, Origin, Parents, ProvedIn, ProvedOut,
                            entry(Vars1, Initial_Const),
                            dual(Vars1, [Initial_Const]),
                            OtherVars, StackIn, StackOut, Model)
     ).
 
-solve_other_forall(Goal, M, Parents, ProvedIn, ProvedOutExit,
+solve_other_forall(Goal, M, Origin, Parents, ProvedIn, ProvedOutExit,
                    entry(Vars, Initial_Const),
                    dual(Vars, [Initial_Const]),
                    OtherVars, StackIn, StackOutExit, ModelExit) :-
@@ -802,7 +804,7 @@ solve_other_forall(Goal, M, Parents, ProvedIn, ProvedOutExit,
     apply_const_store(Constraints1),
     !,
 
-    solve_var_forall_(Goal1, M, Parents1, ProvedIn1, ProvedOut,
+    solve_var_forall_(Goal1, M, Origin, Parents1, ProvedIn1, ProvedOut,
                       entry(Vars1, Initial_Const),
                       dual(Vars1, [Initial_Const]), OtherVars1,
                       StackIn1, StackOut, Model),
@@ -820,14 +822,14 @@ solve_other_forall(Goal, M, Parents, ProvedIn, ProvedOutExit,
         make_duals(AnsConstraints2, Duals),
         member(Dual, Duals),
         apply_const_store(Dual),
-        solve_other_forall(Goal2, M, Parents2, ProvedIn2, ProvedOutExit,
+        solve_other_forall(Goal2, M, Origin, Parents2, ProvedIn2, ProvedOutExit,
                            entry(Vars2, Initial_Const),
                            dual(Vars2, [Initial_Const]),
                            OtherVars2, StackIn2, StackOutExit, ModelExit), !,
         OtherVars = OtherVars2
     ).
 
-%!  solve_var_forall_(+Goal, +Module, +Parents, +ProvedIn, -ProvedOut,
+%!  solve_var_forall_(+Goal, +Module, +Origin, +Parents, +ProvedIn, -ProvedOut,
 %!                    +Entry, +Duals, +OtherVars,
 %!                    +StackIn, -StackOut, -Model) is nondet.
 %
@@ -843,9 +845,9 @@ solve_other_forall(Goal, M, Parents, ProvedIn, ProvedOutExit,
 %   Note that the constraints on the   _forall variables_ are maintained
 %   explicitly.
 
-solve_var_forall_(_Goal, _M, _Parents, Proved, Proved, _, dual(_, []),
+solve_var_forall_(_Goal, _M, _Origin, _Parents, Proved, Proved, _, dual(_, []),
                   _OtherVars, StackIn, StackIn, []) :- !.
-solve_var_forall_(Goal, M, Parents, ProvedIn, ProvedOut,
+solve_var_forall_(Goal, M, Origin, Parents, ProvedIn, ProvedOut,
                   entry(C_Vars, Prev_Store),
                   dual(C_Vars, [C_St|C_Stores]),
                   OtherVars, StackIn, StackOut, Model) :-
@@ -862,11 +864,11 @@ solve_var_forall_(Goal, M, Parents, ProvedIn, ProvedOut,
     apply_const_store(Prev_Store),
     (   %verbose(format('apply_const_store ~@\n',[print_goal(C_St)])),
         apply_const_store(C_St) % apply a Dual
-    ->  solve([Goal], M, Parents, ProvedIn, ProvedOut1, StackIn, [[]|StackOut1], Model1),
+    ->  solve([Goal], M, Origin, Parents, ProvedIn, ProvedOut1, StackIn, [[]|StackOut1], Model1),
         find_duals(C_Vars, C_Vars1, OtherVars, Duals),       %% New Duals
         verbose(format('Duals = \t ~p\n',[Duals])),
         append_set(Prev_Store1, C_St1, Current_Store1),
-        solve_var_forall_(Goal1, M, Parents, ProvedOut1, ProvedOut2,
+        solve_var_forall_(Goal1, M, Origin, Parents, ProvedOut1, ProvedOut2,
                           entry(C_Vars1, Current_Store1),
                           dual(C_Vars1, Duals),
                           OtherVars, StackOut1, StackOut2, Model2),
@@ -878,7 +880,7 @@ solve_var_forall_(Goal, M, Parents, ProvedIn, ProvedOut,
         StackOut2 = StackIn,
         Model3 = []
     ),
-    solve_var_forall_(Goal2, M, Parents, ProvedOut2, ProvedOut,
+    solve_var_forall_(Goal2, M, Origin, Parents, ProvedOut2, ProvedOut,
                       entry(C_Vars2, Prev_Store2),
                       dual(C_Vars2, C_Stores2),
                       OtherVars, StackOut2, StackOut, Model4),
@@ -1068,3 +1070,6 @@ member_var(Vars, Var) :-
     member(V, Vars),
     Var == V,
     !.
+
+member_stack(Goal, Stack) :- member_stack(Goal, Stack, _).
+member_stack(Goal, Stack, Origin) :- member(goal_origin(Goal, Origin), Stack).

--- a/prolog/scasp/stack.pl
+++ b/prolog/scasp/stack.pl
@@ -65,8 +65,8 @@ justification_tree(M:Stack, M:JustificationTree, Options) :-
 %     [p, q, [], []]			p-[q-[]]
 %     [p, q, [], r, [], []]		p-[q-[],r-[]]
 %
-%     We main a stack of  difference  lists   in  the  4th  argument. On
-%     encountering a `[]` we pop this stack.
+%     We maintain a stack of  difference  lists   in  the  4th  argument.
+%     On encountering a `[]` we pop this stack.
 
 stack_tree(Stack, Tree) :-
     stack_tree(Stack, Tree, [], []).

--- a/prolog/scasp/stack.pl
+++ b/prolog/scasp/stack.pl
@@ -52,7 +52,7 @@
 
 justification_tree(M:Stack, M:JustificationTree, Options) :-
     reverse(Stack, RevStack),
-    stack_tree([query|RevStack], Trees),
+    stack_tree([goal_origin(query, query)|RevStack], Trees),
     filter_tree(Trees, M, [JustificationTree], Options).
 
 %!  stack_tree(+Stack, -Tree) is det.
@@ -91,7 +91,7 @@ stack_tree([H|Stack], Tree, T, Parents) =>
 %        Remove all not(_) nodes from the tree.
 
 filter_tree([],_,[], _).
-filter_tree([Term0-Children|Cs], M, Tree, Options) :-
+filter_tree([goal_origin(Term0,_)-Children|Cs], M, Tree, Options) :-
     filter_pos(Term0, Options),
     raise_negation(Term0, Term),
     selected(Term, M), !,

--- a/test/test_just.pl
+++ b/test/test_just.pl
@@ -1,0 +1,46 @@
+:- module(test_just,
+          [ test_just/0
+          ]).
+:- use_module('../prolog/scasp').
+:- use_module('../prolog/scasp/human').
+:- use_module(library(plunit)).
+:- use_module(library(debug)).
+
+:- meta_predicate
+    human(0, +).
+
+test_just :-
+    run_tests([ scasp_just_1
+              ]).
+
+:- begin_tests(scasp_just_1).
+:- dynamic q/0.
+
+p.
+pq :- not q.
+p(X) :- X #> 3.
+
+test(p) :-
+    human(p, "p holds").
+test(p1) :-
+    human(p(_X), "p holds for any number greater than 3").
+test(np1) :-
+    human(not p(_X), "there is no evidence that p holds for \c
+                      any number less than or equal to 3").
+test(pq) :-
+    human(pq, "pq holds, because there is no evidence that q holds").
+
+:- end_tests(scasp_just_1).
+
+
+		 /*******************************
+		 *            HARNASS		*
+		 *******************************/
+
+human(G, Expected) :-
+    once(scasp(G, [tree(Tree)])),
+    with_output_to(string(String0),
+                   human_justification_tree(Tree, [])),
+    split_string(String0, "\n", " \n\u220e", Strings),
+    atomics_to_string(Strings, " ", String),
+    assertion(Expected == String).


### PR DESCRIPTION
This PR extends the internal `pr_rule(Head, Body)` predicate with another argument, `Origin`, which describes the source of the rule. The code that reads and loads s(CASP) code is adjusted accordingly.
The format for the `Origin` term is documented under `defined_rule/4` (which is also extended from `defined_rule/3`):
```
%   @arg Origin A term describing the origin of this rule. For rules that are derived
%   from loaded clauses, Origin is set to `clause(ClauseRef)`; for compiler
%   generated rules, Origin is set to `generated(Why)` where `Why` is one
%   of `neg` for classical negation, `nmr` for NMR checks, and `dual` for dual rules;
%   for rules read directly as s(CASP) with e.g. `load_source_files/1`, Origin is set
%   to `source(Path, Pos)` where `Path` is the path of the source file,
%   and `Pos` is a term describing the postition and layout of the rule in the file.
```

Note that this patch is not intended to have any effect on user-visible behavior, it only sets the ground for leveraging source information in the justification tree to provide better variable names and so on.