### PR TITLE
ENHANCED: justification format for abducible predicates

### DIFF
--- a/prolog/scasp/html.pl
+++ b/prolog/scasp/html.pl
@@ -125,6 +125,13 @@ normal_justification_tree(Term-[], Options) -->
                     \connect(Options)
                   ])
             ])).
+normal_justification_tree('abducible$'(Term)-_, Options) -->
+    !,
+    emit(li([ div(class(node),
+                  [ \tree_atom(abducible(Term), Options),
+                    \connect(Options)
+                  ])
+            ])).
 normal_justification_tree(o_nmr_check-_, Options) -->
     { option(justify_nmr(false), Options) },
     !.
@@ -376,6 +383,9 @@ atom(assume(Term), Options) -->
 atom(chs(Term), Options) -->
     !,
     utter(chs(Term), [class(chs)|Options]).
+atom(abducible(Term), Options) -->
+    !,
+    utter(abducible(Term), [class(abducible)|Options]).
 atom(M:Term, Options) -->
     { atom(M) },
     !,
@@ -431,6 +441,10 @@ utter(proved(Atom), Options) -->
     emit([', ', Text]).
 utter(chs(Atom), Options) -->
     { human_connector(chs, Text) },
+    emit([Text, ' ']),
+    atom(Atom, Options).
+utter(abducible(Atom), Options) -->
+    { human_connector(abducible, Text) },
     emit([Text, ' ']),
     atom(Atom, Options).
 utter(assume(Atom), Options) -->

--- a/prolog/scasp/lang/en.pl
+++ b/prolog/scasp/lang/en.pl
@@ -122,6 +122,7 @@ scasp_message(global_constraints_hold) -->
     [ 'The global constraints hold' ].
 scasp_message(global_constraint(N)) -->
     [ 'the global constraint number ', N, ' holds' ].
+scasp_message(abducible) --> [ 'it is abducible that' ].
 
 
 		 /*******************************


### PR DESCRIPTION
This PR makes a simple enhancement to the output format of the justification tree for `#abducible`s.

For the rock-paper-scissors example we currently have (before this change):
```
?- scasp(winner(the_final_round, john), [tree(Tree)]), human_justification_tree(Tree, []).
   The winner of the_final_round is john, because
      john played in the_final_round, because
         there is no evidence that o_player holds for the_final_round, and john, because
            it is assumed that john played in the_final_round
         abducible$ holds for player(the_final_round,john), because
            there is no evidence that abducible$$ holds for player(the_final_round,john), because
               abducible$ holds for player(the_final_round,john), because
                  it is assumed that there is no evidence that abducible$$ holds for player(the_final_round,john)
      anything played in the_final_round, because
         there is no evidence that o_player holds for the_final_round, and anything, because
            it is assumed that anything played in the_final_round
         abducible$ holds for player(the_final_round,_676), because
            there is no evidence that abducible$$ holds for player(the_final_round,_676), because
               abducible$ holds for player(the_final_round,_676), because
                  it is assumed that there is no evidence that abducible$$ holds for player(the_final_round,_676)
      john threw rock, because
         there is no evidence that o_throw holds for john, and rock, because
            it is assumed that john threw rock
         abducible$ holds for throw(john,rock), because
            there is no evidence that abducible$$ holds for throw(john,rock), because
               abducible$ holds for throw(john,rock), because
                  it is assumed that there is no evidence that abducible$$ holds for throw(john,rock)
      anything threw scissors, because
         there is no evidence that o_throw holds for anything, and scissors, because
            it is assumed that anything threw scissors
         abducible$ holds for throw(_676,scissors), because
            there is no evidence that abducible$$ holds for throw(_676,scissors), because
               abducible$ holds for throw(_676,scissors), because
                  it is assumed that there is no evidence that abducible$$ holds for throw(_676,scissors)
      rock beats scissors
   ∎
```

After this PR, for the same query we get:
```
   The winner of the_final_round is john, because
      john played in the_final_round, because
         there is no evidence that o_player holds for the_final_round, and john, because
            it is assumed that john played in the_final_round
         it is abducible that john played in the_final_round
      anything played in the_final_round, because
         there is no evidence that o_player holds for the_final_round, and anything, because
            it is assumed that anything played in the_final_round
         it is abducible that anything played in the_final_round
      john threw rock, because
         there is no evidence that o_throw holds for john, and rock, because
            it is assumed that john threw rock
         it is abducible that john threw rock
      anything threw scissors, because
         there is no evidence that o_throw holds for anything, and scissors, because
            it is assumed that anything threw scissors
         it is abducible that anything threw scissors
      rock beats scissors
   ∎
```

Tested also with the HTTP interface:
<img width="647" alt="Screen Shot 2022-06-20 at 20 47 39" src="https://user-images.githubusercontent.com/83165320/174657093-725c9996-7b47-4332-b613-8313d8fff09e.png">



