### PR TITLE
Justification improvements

### DIFF
--- a/prolog/scasp/dyncall.pl
+++ b/prolog/scasp/dyncall.pl
@@ -538,25 +538,12 @@ abducible(M:Head, Pos), callable(Head) =>
     discontiguous(M:('abducible$'/1, 'abducible$$'/1)),
     maplist(scasp_assert_into(M, Pos), Rules).
 
-abducible_rules(HeadIn,
-                [ (Head                 :- not AHead, 'abducible$'(Head)),
-                  (AHead                :- not Head),
+abducible_rules(Head,
+                [ (Head                   :- not(-(Head)), 'abducible$'(Head)),
+                  (-(Head)                :- not Head),
                   ('abducible$'(Head)   :- not 'abducible$$'(Head)),
                   ('abducible$$'(Head)  :- not 'abducible$'(Head))
-                ]) :-
-    ab_heads(HeadIn, Head, AHead).
-
-ab_heads(-NHead, Head, AHead) =>
-    NHead =.. [F|Args],
-    atom_concat('-', F, NF),
-    atom_concat('-o_', F, AF),
-    Head =.. [NF|Args],
-    AHead =.. [AF|Args].
-ab_heads(Head0, Head, AHead) =>
-    Head = Head0,
-    Head =.. [F|Args],
-    atom_concat('o_', F, AF),
-    AHead =.. [AF|Args].
+                ]).
 
 
 

--- a/prolog/scasp/html.pl
+++ b/prolog/scasp/html.pl
@@ -448,6 +448,11 @@ utter(global_constraints_hold, _Options) -->
 utter(global_constraint(N), _Options) -->
     { human_connector(global_constraint(N), Text) },
     emit(Text).
+utter(not(-(Atom)), Options) -->
+    !,
+    { human_connector(may, Text) },
+    emit([Text, ' ']),
+    atom(Atom, Options).
 utter(not(Atom), Options) -->
     { human_connector(not, Text) },
     emit([Text, ' ']),

--- a/prolog/scasp/lang/en.pl
+++ b/prolog/scasp/lang/en.pl
@@ -98,6 +98,7 @@ scasp_message(no_models(CPU)) -->
 scasp_message(and)       --> [ 'and' ].
 scasp_message(or)        --> [ 'or' ].
 scasp_message(not)       --> [ 'there is no evidence that' ].
+scasp_message(may)       --> [ 'it may be the case that' ].
 scasp_message(-)         --> [ 'it is not the case that' ].
 scasp_message(implies)   --> [ 'because' ].
 scasp_message(?)         --> [ '?' ].

--- a/prolog/scasp/source_ref.pl
+++ b/prolog/scasp/source_ref.pl
@@ -12,7 +12,10 @@
 scasp_source_reference_file_line(Ref, File, Line) :-
     blob(Ref, clause),
     !,
-    clause_file_line(Ref, File, Line).
+    (   clause_file_line(Ref, File, Line)
+    ->  true
+    ;   File = none, Line = 0
+    ).
 scasp_source_reference_file_line(Ref, File, Line) :-
     scasp_source_reference(Ref, File, Pos),
     !,

--- a/prolog/scasp/stack.pl
+++ b/prolog/scasp/stack.pl
@@ -91,13 +91,16 @@ stack_tree([H|Stack], Tree, T, Parents) =>
 %        Remove all not(_) nodes from the tree.
 
 filter_tree([],_,[], _) :- !.
-filter_tree([goal_origin(Term,_)-[_,goal_origin(Abduced, O)-_]|Cs],
+filter_tree([goal_origin(_,_)-[_,goal_origin(Abd, O)-_]|Cs],
             M,
-            [goal_origin(abduced(Term), O)-[]|Fs], Options) :-
-    Abduced =.. [F, _],
-    (   sub_atom(F, _, _, 0, 'abducible$')
-    ;   F == abducible
-    ),
+            [goal_origin(abduced(Atom), O)-[]|Fs], Options) :-
+    abduction_justification(Abd, Atom),
+    !,
+    filter_tree(Cs, M, Fs, Options).
+filter_tree([proved(Abd)-[]|Cs],
+            M,
+            [proved(Atom)-[]|Fs], Options) :-
+    abduction_justification(Abd, Atom),
     !,
     filter_tree(Cs, M, Fs, Options).
 filter_tree([goal_origin(Term0,O)-Children|Cs], M, Tree, Options) :-
@@ -171,6 +174,17 @@ is_global_constraint(Atom) :-
     atom(Atom),
     atom_concat(o_chk_, NA, Atom),
     atom_number(NA, _).
+
+
+abduction_justification(Abd, Atom) :-
+    Abd =.. [F, Atom],
+    abduction_justification_(F).
+
+abduction_justification_(F) :-
+    sub_atom(F, _, _, 0, 'abducible$'),
+    !.
+abduction_justification_(abducible).
+
 
 %!  print_justification_tree(:Tree) is det.
 %!  print_justification_tree(:Tree, +Options) is det.


### PR DESCRIPTION
As the commit messages suggest, the first three commits are plain bugfixes, while the last commit introduces a small modification in the natural language justification.
The modification is intended to make the justification for classical negation nested in NAF more concise by adding a special case for the pattern `not(-(p))`.

For example with this PR we get:
```
         it may be the case that the bird sam is abnormal, because
            the bird sam is abnormal, because [per /Users/eshelyaron/tmp/birds.pl:16]
               sam is a penguin [per /Users/eshelyaron/tmp/birds.pl:4]
```

Instead of the current:
```
         there is no evidence that it is not the case that the bird sam is abnormal, because
            the bird sam is abnormal, because [per /Users/eshelyaron/tmp/birds.pl:16]
               sam is a penguin [per /Users/eshelyaron/tmp/birds.pl:4]
```
